### PR TITLE
Fix: Change password of db in sonarqube build workflow

### DIFF
--- a/.github/workflows/sonarqube-build.yml
+++ b/.github/workflows/sonarqube-build.yml
@@ -16,7 +16,7 @@ jobs:
         image: postgres
         # Provide the password for postgres
         env:
-          POSTGRES_PASSWORD: asdf
+          POSTGRES_PASSWORD: postgres
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready


### PR DESCRIPTION
Currently, the sonarqube build is failing because of a different password. It is not changed to its default `postgres`