### PR TITLE
Add configuration cloning

### DIFF
--- a/.github/workflows/deploy-docker-image-on-release.yml
+++ b/.github/workflows/deploy-docker-image-on-release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "maintenance/clone-config"
     tags:
       - "v*"
   pull_request:

--- a/.github/workflows/deploy-docker-image-on-release.yml
+++ b/.github/workflows/deploy-docker-image-on-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - "maintenance/clone-config"
     tags:
       - "v*"
   pull_request:

--- a/src/main/java/de/unistuttgart/chickenshockbackend/Constants.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/Constants.java
@@ -23,6 +23,5 @@ public final class Constants {
     public static final long MIN_SCORE = 0;
     public static final long MAX_SCORE = 100;
 
-    private Constants() {
-    }
+    private Constants() {}
 }

--- a/src/main/java/de/unistuttgart/chickenshockbackend/controller/ConfigController.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/controller/ConfigController.java
@@ -137,4 +137,12 @@ public class ConfigController {
         log.debug("update question {} with {} for configuration {}", questionId, questionDTO, id);
         return configService.updateQuestionFromConfiguration(id, questionId, questionDTO);
     }
+
+    @PostMapping("/{id}/clone")
+    @ResponseStatus(HttpStatus.CREATED)
+    public UUID cloneConfiguration(@CookieValue("access_token") final String accessToken, @PathVariable final UUID id) {
+        jwtValidatorService.validateTokenOrThrow(accessToken);
+        jwtValidatorService.hasRolesOrThrow(accessToken, List.of("lecturer"));
+        return configService.cloneConfiguration(id);
+    }
 }

--- a/src/main/java/de/unistuttgart/chickenshockbackend/controller/ConfigController.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/controller/ConfigController.java
@@ -6,11 +6,10 @@ import de.unistuttgart.chickenshockbackend.data.mapper.ConfigurationMapper;
 import de.unistuttgart.chickenshockbackend.repositories.ConfigurationRepository;
 import de.unistuttgart.chickenshockbackend.service.ConfigService;
 import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import java.util.UUID;
 import javax.validation.Valid;
-
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;

--- a/src/main/java/de/unistuttgart/chickenshockbackend/controller/GameResultController.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/controller/GameResultController.java
@@ -3,9 +3,8 @@ package de.unistuttgart.chickenshockbackend.controller;
 import de.unistuttgart.chickenshockbackend.data.GameResultDTO;
 import de.unistuttgart.chickenshockbackend.service.GameResultService;
 import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
-import javax.validation.Valid;
-
 import io.swagger.v3.oas.annotations.Operation;
+import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;

--- a/src/main/java/de/unistuttgart/chickenshockbackend/data/Configuration.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/data/Configuration.java
@@ -1,17 +1,17 @@
 package de.unistuttgart.chickenshockbackend.data;
 
 import de.unistuttgart.chickenshockbackend.Constants;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.persistence.*;
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.springframework.validation.annotation.Validated;
-
-import javax.persistence.*;
-import javax.validation.Valid;
-import javax.validation.constraints.Min;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * The Configuration.class contains all data that has to be stored to configure a chickenshock game
@@ -62,5 +62,18 @@ public class Configuration {
      */
     public void removeQuestion(final Question question) {
         this.questions.remove(question);
+    }
+
+    @Override
+    public Object clone() {
+        Configuration config;
+        try {
+            config = (Configuration) super.clone();
+        } catch (CloneNotSupportedException e) {
+            config = new Configuration(this.getQuestions(), this.time);
+        }
+        config.questions =
+            this.questions.stream().map(question -> question = (Question) question.clone()).collect(Collectors.toSet());
+        return config;
     }
 }

--- a/src/main/java/de/unistuttgart/chickenshockbackend/data/Configuration.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/data/Configuration.java
@@ -65,15 +65,10 @@ public class Configuration {
     }
 
     @Override
-    public Object clone() {
-        Configuration config;
-        try {
-            config = (Configuration) super.clone();
-        } catch (CloneNotSupportedException e) {
-            config = new Configuration(this.getQuestions(), this.time);
-        }
-        config.questions =
-            this.questions.stream().map(question -> question = (Question) question.clone()).collect(Collectors.toSet());
-        return config;
+    public Configuration clone() {
+        return new Configuration(
+            this.questions.stream().map(question -> question = question.clone()).collect(Collectors.toSet()),
+            this.time
+        );
     }
 }

--- a/src/main/java/de/unistuttgart/chickenshockbackend/data/Configuration.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/data/Configuration.java
@@ -66,9 +66,6 @@ public class Configuration {
 
     @Override
     public Configuration clone() {
-        return new Configuration(
-            this.questions.stream().map(question -> question = question.clone()).collect(Collectors.toSet()),
-            this.time
-        );
+        return new Configuration(this.questions.stream().map(Question::clone).collect(Collectors.toSet()), this.time);
     }
 }

--- a/src/main/java/de/unistuttgart/chickenshockbackend/data/ConfigurationDTO.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/data/ConfigurationDTO.java
@@ -1,6 +1,11 @@
 package de.unistuttgart.chickenshockbackend.data;
 
 import de.unistuttgart.chickenshockbackend.Constants;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,12 +13,6 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
-
-import javax.validation.Valid;
-import javax.validation.constraints.Min;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * The ConfigurationDTO.class contains all data that has to be stored to configure a chickenshock game

--- a/src/main/java/de/unistuttgart/chickenshockbackend/data/GameResult.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/data/GameResult.java
@@ -1,20 +1,19 @@
 package de.unistuttgart.chickenshockbackend.data;
 
 import de.unistuttgart.chickenshockbackend.Constants;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.FieldDefaults;
-import org.springframework.validation.annotation.Validated;
-
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 import javax.persistence.*;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * The GameResult.class contains all data that is saved after one chickenshock game

--- a/src/main/java/de/unistuttgart/chickenshockbackend/data/GameResultDTO.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/data/GameResultDTO.java
@@ -1,6 +1,12 @@
 package de.unistuttgart.chickenshockbackend.data;
 
 import de.unistuttgart.chickenshockbackend.Constants;
+import java.util.List;
+import java.util.UUID;
+import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,13 +14,6 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
-
-import javax.validation.Valid;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import java.util.List;
-import java.util.UUID;
 
 /**
  * The GameResultDTO.class contains all data that is saved after one chickenshock game

--- a/src/main/java/de/unistuttgart/chickenshockbackend/data/OverworldResultDTO.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/data/OverworldResultDTO.java
@@ -1,18 +1,17 @@
 package de.unistuttgart.chickenshockbackend.data;
 
 import de.unistuttgart.chickenshockbackend.Constants;
+import java.util.UUID;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.springframework.validation.annotation.Validated;
-
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import java.util.UUID;
 
 /**
  * The OverworldResultDTO.class contains all the info that is sent to the Overworld-backend as the result of a game.

--- a/src/main/java/de/unistuttgart/chickenshockbackend/data/Question.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/data/Question.java
@@ -60,6 +60,6 @@ public class Question {
 
     @Override
     public Question clone() {
-        return new Question(this.text, this.rightAnswer, new HashSet<>(this.wrongAnswers) {});
+        return new Question(this.text, this.rightAnswer, new HashSet<>(this.wrongAnswers));
     }
 }

--- a/src/main/java/de/unistuttgart/chickenshockbackend/data/Question.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/data/Question.java
@@ -1,5 +1,6 @@
 package de.unistuttgart.chickenshockbackend.data;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import javax.persistence.ElementCollection;
@@ -55,5 +56,14 @@ public class Question {
         this.text = text;
         this.rightAnswer = rightAnswer;
         this.wrongAnswers = wrongAnswers;
+    }
+
+    @Override
+    public Object clone() {
+        try {
+            return super.clone();
+        } catch (CloneNotSupportedException e) {
+            return new Question(this.text, this.rightAnswer, new HashSet<>(this.wrongAnswers) {});
+        }
     }
 }

--- a/src/main/java/de/unistuttgart/chickenshockbackend/data/Question.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/data/Question.java
@@ -59,11 +59,7 @@ public class Question {
     }
 
     @Override
-    public Object clone() {
-        try {
-            return super.clone();
-        } catch (CloneNotSupportedException e) {
-            return new Question(this.text, this.rightAnswer, new HashSet<>(this.wrongAnswers) {});
-        }
+    public Question clone() {
+        return new Question(this.text, this.rightAnswer, new HashSet<>(this.wrongAnswers) {});
     }
 }

--- a/src/main/java/de/unistuttgart/chickenshockbackend/service/ConfigService.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/service/ConfigService.java
@@ -208,7 +208,7 @@ public class ConfigService {
                     String.format("Configuration with id %s not found", id)
                 )
             );
-        Configuration cloneConfig = (Configuration) config.clone();
+        Configuration cloneConfig = config.clone();
         cloneConfig = configurationRepository.save(cloneConfig);
         return cloneConfig.getId();
     }

--- a/src/main/java/de/unistuttgart/chickenshockbackend/service/ConfigService.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/service/ConfigService.java
@@ -8,7 +8,6 @@ import de.unistuttgart.chickenshockbackend.data.mapper.ConfigurationMapper;
 import de.unistuttgart.chickenshockbackend.data.mapper.QuestionMapper;
 import de.unistuttgart.chickenshockbackend.repositories.ConfigurationRepository;
 import de.unistuttgart.chickenshockbackend.repositories.QuestionRepository;
-
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -201,14 +200,17 @@ public class ConfigService {
      * @return the new id of the cloned configuration
      */
     public UUID cloneConfiguration(final UUID id) {
-        Configuration config = configurationRepository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, String.format("Configuration with id %s not found", id)));
-        final Configuration cloneConfig = new Configuration(new HashSet<>(), config.getTime());
-        config.getQuestions().forEach(question -> {
-            Set<String> wrongAnswers = new HashSet<>(question.getWrongAnswers());
-            cloneConfig.addQuestion(new Question(question.getText(), question.getRightAnswer(), wrongAnswers));
-        });
-        Configuration idConfig = configurationRepository.save(cloneConfig);
-        return idConfig.getId();
+        Configuration config = configurationRepository
+            .findById(id)
+            .orElseThrow(() ->
+                new ResponseStatusException(
+                    HttpStatus.NOT_FOUND,
+                    String.format("Configuration with id %s not found", id)
+                )
+            );
+        Configuration cloneConfig = (Configuration) config.clone();
+        cloneConfig = configurationRepository.save(cloneConfig);
+        return cloneConfig.getId();
     }
 
     /**

--- a/src/main/java/de/unistuttgart/chickenshockbackend/service/ConfigService.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/service/ConfigService.java
@@ -8,7 +8,10 @@ import de.unistuttgart.chickenshockbackend.data.mapper.ConfigurationMapper;
 import de.unistuttgart.chickenshockbackend.data.mapper.QuestionMapper;
 import de.unistuttgart.chickenshockbackend.repositories.ConfigurationRepository;
 import de.unistuttgart.chickenshockbackend.repositories.QuestionRepository;
+
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -189,6 +192,23 @@ public class ConfigService {
         question.setId(questionId);
         final Question savedQuestion = questionRepository.save(question);
         return questionMapper.questionToQuestionDTO(savedQuestion);
+    }
+
+    /**
+     * Clones the configuration with the given id
+     *
+     * @param id the id of the configuration to be cloned
+     * @return the new id of the cloned configuration
+     */
+    public UUID cloneConfiguration(final UUID id) {
+        Configuration config = configurationRepository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, String.format("Configuration with id %s not found", id)));
+        final Configuration cloneConfig = new Configuration(new HashSet<>(), config.getTime());
+        config.getQuestions().forEach(question -> {
+            Set<String> wrongAnswers = new HashSet<>(question.getWrongAnswers());
+            cloneConfig.addQuestion(new Question(question.getText(), question.getRightAnswer(), wrongAnswers));
+        });
+        Configuration idConfig = configurationRepository.save(cloneConfig);
+        return idConfig.getId();
     }
 
     /**

--- a/src/main/java/de/unistuttgart/chickenshockbackend/service/GameResultService.java
+++ b/src/main/java/de/unistuttgart/chickenshockbackend/service/GameResultService.java
@@ -42,7 +42,11 @@ public class GameResultService {
      * @param accessToken accessToken of the user
      * @throws IllegalArgumentException if at least one of the arguments is null
      */
-    public void saveGameResult(final @Valid GameResultDTO gameResultDTO, final String userId, final String accessToken) {
+    public void saveGameResult(
+        final @Valid GameResultDTO gameResultDTO,
+        final String userId,
+        final String accessToken
+    ) {
         if (gameResultDTO == null || userId == null || accessToken == null) {
             throw new IllegalArgumentException("gameResultDTO or userId or accessToken is null");
         }

--- a/src/test/java/de/unistuttgart/chickenshockbackend/ConfigControllerTest.java
+++ b/src/test/java/de/unistuttgart/chickenshockbackend/ConfigControllerTest.java
@@ -311,4 +311,18 @@ class ConfigControllerTest {
             .andExpect(status().isNotFound())
             .andReturn();
     }
+
+    @Test
+    void testCloneConfiguration() throws Exception {
+        final MvcResult result = mvc
+                .perform(post(API_URL + "/" + initialConfig.getId() + "/clone").cookie(cookie).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andReturn();
+        final String content = result.getResponse().getContentAsString();
+        final UUID clonedId = objectMapper.readValue(content, UUID.class);
+        assertNotEquals(initialConfig.getId(), clonedId);
+
+        final Configuration cloneConfig = configurationRepository.findById(clonedId).get();
+        assertNotEquals(cloneConfig, initialConfig);
+    }
 }

--- a/src/test/java/de/unistuttgart/chickenshockbackend/ConfigControllerTest.java
+++ b/src/test/java/de/unistuttgart/chickenshockbackend/ConfigControllerTest.java
@@ -315,14 +315,27 @@ class ConfigControllerTest {
     @Test
     void testCloneConfiguration() throws Exception {
         final MvcResult result = mvc
-                .perform(post(API_URL + "/" + initialConfig.getId() + "/clone").cookie(cookie).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated())
-                .andReturn();
+            .perform(
+                post(API_URL + "/" + initialConfig.getId() + "/clone")
+                    .cookie(cookie)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isCreated())
+            .andReturn();
         final String content = result.getResponse().getContentAsString();
         final UUID clonedId = objectMapper.readValue(content, UUID.class);
         assertNotEquals(initialConfig.getId(), clonedId);
 
         final Configuration cloneConfig = configurationRepository.findById(clonedId).get();
+        cloneConfig
+            .getQuestions()
+            .forEach(question ->
+                initialConfig
+                    .getQuestions()
+                    .forEach(initialQuestion -> {
+                        assertNotEquals(question.getId(), initialQuestion.getId());
+                    })
+            );
         assertNotEquals(cloneConfig, initialConfig);
     }
 }


### PR DESCRIPTION
Part of https://github.com/Gamify-IT/issues/issues/387

Adds the option to clone a configuration.

This backend is the same as the towercrush- and finitequiz-backend.

To test use the description in the overworld-backend pull request.