### PR TITLE
Add database migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <plugin.prettier.goal>write</plugin.prettier.goal>
         <spring-cloud.version>2021.0.3</spring-cloud.version>
         <org.springdoc.version>1.6.9</org.springdoc.version>
+        <liquibase.version>4.19.0</liquibase.version>
     </properties>
     <dependencies>
         <dependency>
@@ -85,6 +86,11 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>${org.springdoc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>${liquibase.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,6 @@ keycloak.url=http://localhost/keycloak/realms/Gamify-IT
 springdoc.swagger-ui.path=/swagger-ui
 springdoc.swagger-ui.disable-swagger-default-url=true
 server.error.include-message=always
+
+spring.liquibase.change-log=classpath:db/changelog-root.xml
+

--- a/src/main/resources/db/changelog-root.xml
+++ b/src/main/resources/db/changelog-root.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd
+      http://www.liquibase.org/xml/ns/pro
+      http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd">
+<includeAll path="db/changelog/"/><!-- Automatically queries all files in this directory in lexical order -->
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-1.0.sql
+++ b/src/main/resources/db/changelog/changelog-1.0.sql
@@ -1,0 +1,53 @@
+-- liquibase formatted sql
+
+-- changeset leon:change1-1
+CREATE TABLE "configuration" ("id" UUID NOT NULL, "time" INTEGER NOT NULL, CONSTRAINT "configuration_pkey" PRIMARY KEY ("id"));
+
+-- changeset leon:change1-2
+CREATE TABLE "game_result" ("id" UUID NOT NULL, "configuration_asuuid" UUID NOT NULL, "correct_kills_count" INTEGER NOT NULL, "finished_in_seconds" FLOAT4 NOT NULL, "kills_count" INTEGER NOT NULL, "played_time" TIMESTAMP WITHOUT TIME ZONE NOT NULL, "player_id" VARCHAR(255) NOT NULL, "points" INTEGER NOT NULL, "question_count" INTEGER NOT NULL, "shot_count" INTEGER NOT NULL, "time_limit" FLOAT4 NOT NULL, "wrong_kills_count" INTEGER NOT NULL, CONSTRAINT "game_result_pkey" PRIMARY KEY ("id"));
+
+-- changeset leon:change1-3
+CREATE TABLE "configuration_questions" ("configuration_id" UUID NOT NULL, "questions_id" UUID NOT NULL, CONSTRAINT "configuration_questions_pkey" PRIMARY KEY ("configuration_id", "questions_id"));
+
+-- changeset leon:change1-4
+ALTER TABLE "configuration_questions" ADD CONSTRAINT "uk_87jmj05cn4rqb8wfq6qxej42w" UNIQUE ("questions_id");
+
+-- changeset leon:change1-5
+CREATE TABLE "game_result_correct_answered_questions" ("game_result_id" UUID NOT NULL, "correct_answered_questions_id" UUID NOT NULL);
+
+-- changeset leon:change1-6
+CREATE TABLE "game_result_wrong_answered_questions" ("game_result_id" UUID NOT NULL, "wrong_answered_questions_id" UUID NOT NULL);
+
+-- changeset leon:change1-7
+CREATE TABLE "question" ("id" UUID NOT NULL, "right_answer" VARCHAR(255) NOT NULL, "text" VARCHAR(255) NOT NULL, CONSTRAINT "question_pkey" PRIMARY KEY ("id"));
+
+-- changeset leon:change1-8
+CREATE TABLE "question_wrong_answers" ("question_id" UUID NOT NULL, "wrong_answers" VARCHAR(255));
+
+-- changeset leon:change1-9
+CREATE TABLE "round_result" ("id" UUID NOT NULL, "answer" VARCHAR(255) NOT NULL, "question_id" UUID NOT NULL, CONSTRAINT "round_result_pkey" PRIMARY KEY ("id"));
+
+-- changeset leon:change1-10
+ALTER TABLE "game_result_correct_answered_questions" ADD CONSTRAINT "fk2yr4n6edjx6h62qhjfj0x0n9h" FOREIGN KEY ("correct_answered_questions_id") REFERENCES "round_result" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-11
+ALTER TABLE "game_result_wrong_answered_questions" ADD CONSTRAINT "fk5l5weg5gvyjdyjutrqiigreqc" FOREIGN KEY ("wrong_answered_questions_id") REFERENCES "round_result" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-12
+ALTER TABLE "question_wrong_answers" ADD CONSTRAINT "fk9thusvh2s8wjgxjf3gkwr7bnu" FOREIGN KEY ("question_id") REFERENCES "question" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-13
+ALTER TABLE "game_result_wrong_answered_questions" ADD CONSTRAINT "fkbmqsqjwwrhconh1qhvfv7nyta" FOREIGN KEY ("game_result_id") REFERENCES "game_result" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-14
+ALTER TABLE "configuration_questions" ADD CONSTRAINT "fkewy22y8x7me09uka66yaovavm" FOREIGN KEY ("questions_id") REFERENCES "question" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-15
+ALTER TABLE "round_result" ADD CONSTRAINT "fknbh8yrgf47myl1mfiv2johows" FOREIGN KEY ("question_id") REFERENCES "question" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-16
+ALTER TABLE "configuration_questions" ADD CONSTRAINT "fkpuxg1dtbsi0no6cj8ynv0f8tt" FOREIGN KEY ("configuration_id") REFERENCES "configuration" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- changeset leon:change1-17
+ALTER TABLE "game_result_correct_answered_questions" ADD CONSTRAINT "fkrf30lgepnva24yiwi6en9oedc" FOREIGN KEY ("game_result_id") REFERENCES "game_result" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+


### PR DESCRIPTION
In the future, any PR that changes stored data must also adapt the corresponding changelog under `src/main/resources/db/changelog/changelog-<version>.sql`.
New versions should also use a new changelog instead of appending to an old one.
For details on how to keep the changelog up to date, consult the docs.
Part of Gamify-IT/issues#439.
Replaces #37.